### PR TITLE
Update sensorTag examples for node-sensortag 1.0.0

### DIFF
--- a/sensorTag/sensorTagExample/package.json
+++ b/sensorTag/sensorTagExample/package.json
@@ -9,6 +9,6 @@
   "author": "Tom Igoe",
   "license": "ISC",
   "dependencies": {
-    "sensortag": "^0.1.11"
+    "sensortag": "^1.0.0"
   }
 }

--- a/sensorTag/sensorTagExample/sensortagAccelerometer.js
+++ b/sensorTag/sensorTagExample/sensortagAccelerometer.js
@@ -8,15 +8,13 @@
 	there is a sequence you need to follow in order to successfully
 	read a tag:
 		1) discover the tag
-		2) connect to the tag
-		3) read its services and characteristics
-		4) turn on the sensor you want to use (in this case, accelerometer)
-		5) turn on notifications for the sensor
-		6) listen for changes from the sensortag
+		2) connect to and set up the tag
+		3) turn on the sensor you want to use (in this case, accelerometer)
+		4) turn on notifications for the sensor
+		5) listen for changes from the sensortag
 
 	This example does all of those steps in sequence by having each function
-	call the next as a callback. Discover calls connect, which calls
-	discoverServicesAndCharacteristics, and so forth.
+	call the next as a callback. Discover calls connectAndSetUp, and so forth.
 
 	This example is heavily indebted to Sandeep's test for the library, but
 	achieves more or less the same thing without using the async library.
@@ -36,15 +34,9 @@ SensorTag.discover(function(tag) {
 		process.exit(0);
 	});
 
-	function connectMe() {			// attempt to connect to the tag
-     console.log('connect');
-     tag.connect(discoverMe);		// when you connect, call discoverMe
-   }
-
-   function discoverMe() {			// attempt to discover services
-     console.log('discoverServicesAndCharacteristics');
-     // when you discover services, enable the accelerometer:
-     tag.discoverServicesAndCharacteristics(enableAccelMe);
+	function connectAndSetUpMe() {			// attempt to connect to the tag
+     console.log('connectAndSetUp');
+     tag.connectAndSetUp(enableAccelMe);		// when you connect and device is setup, call enableAccelMe
    }
 
    function enableAccelMe() {		// attempt to enable the accelerometer
@@ -84,5 +76,5 @@ SensorTag.discover(function(tag) {
 	}
 
 	// Now that you've defined all the functions, start the process:
-	connectMe();
+	connectAndSetUpMe();
 });

--- a/sensorTag/sensorTagExample/sensortagAccelerometer.js
+++ b/sensorTag/sensorTagExample/sensortagAccelerometer.js
@@ -1,10 +1,10 @@
 /*
 	sensorTag Accelerometer example
-	
+
 	This example uses Sandeep Mistry's sensortag library for node.js to
 	read data from a TI sensorTag.
-	
-	Although the sensortag library functions are all asynchronous, 
+
+	Although the sensortag library functions are all asynchronous,
 	there is a sequence you need to follow in order to successfully
 	read a tag:
 		1) discover the tag
@@ -13,14 +13,14 @@
 		4) turn on the sensor you want to use (in this case, accelerometer)
 		5) turn on notifications for the sensor
 		6) listen for changes from the sensortag
-		
+
 	This example does all of those steps in sequence by having each function
 	call the next as a callback. Discover calls connect, which calls
 	discoverServicesAndCharacteristics, and so forth.
-	
+
 	This example is heavily indebted to Sandeep's test for the library, but
 	achieves more or less the same thing without using the async library.
-	
+
 	created 15 Jan 2014
 	by Tom Igoe
 */
@@ -28,14 +28,14 @@
 
 var SensorTag = require('sensortag');		// sensortag library
 
-// listen for tags: 
+// listen for tags:
 SensorTag.discover(function(tag) {
 	// when you disconnect from a tag, exit the program:
 	tag.on('disconnect', function() {
 		console.log('disconnected!');
 		process.exit(0);
 	});
-		
+
 	function connectMe() {			// attempt to connect to the tag
      console.log('connect');
      tag.connect(discoverMe);		// when you connect, call discoverMe
@@ -46,18 +46,18 @@ SensorTag.discover(function(tag) {
      // when you discover services, enable the accelerometer:
      tag.discoverServicesAndCharacteristics(enableAccelMe);
    }
-   
+
    function enableAccelMe() {		// attempt to enable the accelerometer
      console.log('enableAccelerometer');
      // when you enable the accelerometer, start accelerometer notifications:
      tag.enableAccelerometer(notifyMe);
    }
-   	
+
 	function notifyMe() {
-   	tag.notifyAccelerometer(listenForAcc);   	// start the accelerometer listener 
+   	tag.notifyAccelerometer(listenForAcc);   	// start the accelerometer listener
 		tag.notifySimpleKey(listenForButton);		// start the button listener
    }
-   
+
    // When you get an accelermeter change, print it out:
 	function listenForAcc() {
 		tag.on('accelerometerChange', function(x, y, z) {
@@ -66,13 +66,13 @@ SensorTag.discover(function(tag) {
 	     console.log('\tz = %d G', z.toFixed(1));
 	   });
 	}
-	
+
 	// when you get a button change, print it out:
 	function listenForButton() {
 		tag.on('simpleKeyChange', function(left, right) {
 			if (left) {
 				console.log('left: ' + left);
-			} 
+			}
 			if (right) {
 				console.log('right: ' + right);
 			}
@@ -82,7 +82,7 @@ SensorTag.discover(function(tag) {
 			}
 	   });
 	}
-	
+
 	// Now that you've defined all the functions, start the process:
 	connectMe();
 });

--- a/sensorTag/sensorTagExample/sensortagIRTemperature.js
+++ b/sensorTag/sensorTagExample/sensortagIRTemperature.js
@@ -8,15 +8,13 @@
 	there is a sequence you need to follow in order to successfully
 	read a tag:
 		1) discover the tag
-		2) connect to the tag
-		3) read its services and characteristics
-		4) turn on the sensor you want to use (in this case, accelerometer)
-		5) turn on notifications for the sensor
-		6) listen for changes from the sensortag
+		2) connect to and set up the tag
+		3) turn on the sensor you want to use (in this case, IR temp)
+		4) turn on notifications for the sensor
+		5) listen for changes from the sensortag
 
 	This example does all of those steps in sequence by having each function
-	call the next as a callback. Discover calls connect, which calls
-	discoverServicesAndCharacteristics, and so forth.
+	call the next as a callback. Discover calls connectAndSetUp and so forth.
 
 	This example is heavily indebted to Sandeep's test for the library, but
 	achieves more or less the same thing without using the async library.
@@ -37,15 +35,9 @@ SensorTag.discover(function(tag) {
 		process.exit(0);
 	});
 
-	function connectMe() {			// attempt to connect to the tag
-     console.log('connect');
-     tag.connect(discoverMe);		// when you connect, call discoverMe
-   }
-
-   function discoverMe() {			// attempt to discover services
-     console.log('discoverServicesAndCharacteristics');
-     // when you discover services, enable the accelerometer:
-     tag.discoverServicesAndCharacteristics(enableIrTempMe);
+	function connectAndSetUpMe() {			// attempt to connect to the tag
+     console.log('connectAndSetUp');
+     tag.connectAndSetUp(enableIrTempMe);		// when you connect, call enableIrTempMe
    }
 
    function enableIrTempMe() {		// attempt to enable the IR Temperature sensor
@@ -84,5 +76,5 @@ SensorTag.discover(function(tag) {
 	}
 
 	// Now that you've defined all the functions, start the process:
-	connectMe();
+	connectAndSetUpMe();
 });

--- a/sensorTag/sensorTagSlideshow/sensortagController.js
+++ b/sensorTag/sensorTagSlideshow/sensortagController.js
@@ -8,15 +8,13 @@
 	there is a sequence you need to follow in order to successfully
 	read a tag:
 		1) discover the tag
-		2) connect to the tag
-		3) read its services and characteristics
-		4) turn on the sensor you want to use (in this case, accelerometer)
-		5) turn on notifications for the sensor
-		6) listen for changes from the sensortag
+		2) connect to and set up the tag
+		3) turn on the sensor you want to use (in this case, accelerometer)
+		4) turn on notifications for the sensor
+		5) listen for changes from the sensortag
 
 	This example does all of those steps in sequence by having each function
-	call the next as a callback. Discover calls connect, which calls
-	discoverServicesAndCharacteristics, and so forth.
+	call the next as a callback. Discover calls connectAndSetUpMe and so forth.
 
 	This example is heavily indebted to Sandeep's test for the library, but
 	achieves more or less the same thing without using the async library.
@@ -53,15 +51,9 @@ SensorTag.discover(function(tag) {
 		process.exit(0);
 	});
 
-	function connectMe() {			// attempt to connect to the tag
-     console.log('connect');
-     tag.connect(discoverMe);		// when you connect, call discoverMe
-   }
-
-   function discoverMe() {			// attempt to discover services
-     console.log('discoverServicesAndCharacteristics');
-     // when you discover services, enable the accelerometer:
-     tag.discoverServicesAndCharacteristics(notifyMe);
+	function connectAndSetUpMe() {			// attempt to connect to the tag
+     console.log('connectAndSetUp');
+     tag.connectAndSetUp(notifyMe);		// when you connect, call notifyMe
    }
 
 	function notifyMe() {
@@ -88,5 +80,5 @@ SensorTag.discover(function(tag) {
 	}
 
 	// Now that you've defined all the functions, start the process:
-	connectMe();
+	connectAndSetUpMe();
 });


### PR DESCRIPTION
Main change is condensing the ```connect``` + ```discoverServicesAndCharacteristics``` steps to use the new ```connectAndSetUp``` API.

Upgrading to node-sensortag 1.0.0 also allows the examples to work with the new [CC2650 SensorTag](http://www.ti.com/tool/cc2650stk).